### PR TITLE
node-file-manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "node-nodejs-basics",
+  "version": "1.0.0",
+  "description": "This repository is the part of nodejs-assignments https://github.com/AlreadyBored/nodejs-assignments",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.js",
+    "start:n": "node src/index.js --username=MyName"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ElenVasileva/node-file-manager.git"
+  }
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,5 @@
+
+const invalidInputMessage = 'Invalid input'
+const operationFailedMessage = 'Operation failed'
+
+export default { invalidInputMessage, operationFailedMessage }

--- a/src/fileOperations.js
+++ b/src/fileOperations.js
@@ -1,9 +1,8 @@
 import { pipeline } from 'stream/promises';
 import { createReadStream, createWriteStream } from 'fs';
 import fs from 'fs/promises';
-import path from 'path';
 
-import { parseTwoPaths } from './fsHelper.js'
+import { parseTwoPaths, join } from './fsHelper.js'
 import constants from './constants.js'
 
 
@@ -17,7 +16,7 @@ const removeCommand = 'rm '
 const printFile = async (workPath, input) => {
     try {
         const inputPath = input.substring(catCommand.length)
-        const fileName = path.join(workPath, inputPath)
+        const fileName = join(workPath, inputPath)
         await pipeline(
             createReadStream(fileName),
             process.stdout, { end: false }
@@ -33,7 +32,7 @@ const createFile = async (workPath, input) => {
     let fileDescriptor
     try {
         const inputPath = input.substring(catCommand.length)
-        const fileName = path.join(workPath, inputPath);
+        const fileName = join(workPath, inputPath);
         fileDescriptor = await fs.open(fileName, 'wx');
         await fs.writeFile(fileDescriptor, '')
         return ''
@@ -50,8 +49,8 @@ const renameFile = async (workPath, input) => {
     try {
         const paths = parseTwoPaths(input.substring(renameCommand.length))
         if (paths) {
-            const oldFilePath = path.join(workPath, paths.first)
-            const newFilePath = path.join(workPath, paths.second)
+            const oldFilePath = join(workPath, paths.first)
+            const newFilePath = join(workPath, paths.second)
             await fs.rename(oldFilePath, newFilePath)
             return ''
         }
@@ -68,8 +67,8 @@ const copyFile = async (workPath, input) => {
     try {
         const paths = parseTwoPaths(input.substring(renameCommand.length))
         if (paths) {
-            const oldFilePath = path.join(workPath, paths.first)
-            const newFilePath = path.join(workPath, paths.second)
+            const oldFilePath = join(workPath, paths.first)
+            const newFilePath = join(workPath, paths.second)
             await pipeline(
                 createReadStream(oldFilePath),
                 createWriteStream(newFilePath),
@@ -89,8 +88,8 @@ const moveFile = async (workPath, input) => {
     try {
         const paths = parseTwoPaths(input.substring(renameCommand.length))
         if (paths) {
-            const oldFilePath = path.join(workPath, paths.first)
-            const newFilePath = path.join(workPath, paths.second)
+            const oldFilePath = join(workPath, paths.first)
+            const newFilePath = join(workPath, paths.second)
             await pipeline(
                 createReadStream(oldFilePath),
                 createWriteStream(newFilePath),
@@ -111,7 +110,7 @@ const moveFile = async (workPath, input) => {
 const removeFile = async (workPath, input) => {
     try {
         const inputPath = input.substring(removeCommand.length)
-        const fileName = path.join(workPath, inputPath);
+        const fileName = join(workPath, inputPath);
         await fs.unlink(fileName)
         return ''
     }

--- a/src/fileOperations.js
+++ b/src/fileOperations.js
@@ -1,0 +1,126 @@
+import { pipeline } from 'stream/promises';
+import { createReadStream, createWriteStream } from 'fs';
+import fs from 'fs/promises';
+import path from 'path';
+
+import { parseTwoPaths } from './fsHelper.js'
+import constants from './constants.js'
+
+
+const catCommand = 'cat '
+const addCommand = 'add '
+const renameCommand = 'rn '
+const copyCommand = 'cp '
+const moveCommand = 'mv '
+const removeCommand = 'rm '
+
+const printFile = async (workPath, input) => {
+    try {
+        const inputPath = input.substring(catCommand.length)
+        const fileName = path.join(workPath, inputPath)
+        await pipeline(
+            createReadStream(fileName),
+            process.stdout, { end: false }
+        );
+        return ''
+    }
+    catch {
+        return constants.operationFailedMessage
+    }
+};
+
+const createFile = async (workPath, input) => {
+    let fileDescriptor
+    try {
+        const inputPath = input.substring(catCommand.length)
+        const fileName = path.join(workPath, inputPath);
+        fileDescriptor = await fs.open(fileName, 'wx');
+        await fs.writeFile(fileDescriptor, '')
+        return ''
+    }
+    catch {
+        return constants.operationFailedMessage
+    }
+    finally {
+        await fileDescriptor?.close()
+    }
+};
+
+const renameFile = async (workPath, input) => {
+    try {
+        const paths = parseTwoPaths(input.substring(renameCommand.length))
+        if (paths) {
+            const oldFilePath = path.join(workPath, paths.first)
+            const newFilePath = path.join(workPath, paths.second)
+            await fs.rename(oldFilePath, newFilePath)
+            return ''
+        }
+        else {
+            return constants.invalidInputMessage
+        }
+    }
+    catch {
+        return constants.operationFailedMessage
+    }
+};
+
+const copyFile = async (workPath, input) => {
+    try {
+        const paths = parseTwoPaths(input.substring(renameCommand.length))
+        if (paths) {
+            const oldFilePath = path.join(workPath, paths.first)
+            const newFilePath = path.join(workPath, paths.second)
+            await pipeline(
+                createReadStream(oldFilePath),
+                createWriteStream(newFilePath),
+            );
+            return ''
+        }
+        else {
+            return constants.invalidInputMessage
+        }
+    }
+    catch {
+        return constants.operationFailedMessage
+    }
+};
+
+const moveFile = async (workPath, input) => {
+    try {
+        const paths = parseTwoPaths(input.substring(renameCommand.length))
+        if (paths) {
+            const oldFilePath = path.join(workPath, paths.first)
+            const newFilePath = path.join(workPath, paths.second)
+            await pipeline(
+                createReadStream(oldFilePath),
+                createWriteStream(newFilePath),
+            );
+            await fs.rm(oldFilePath)
+            return ''
+        }
+        else {
+            return constants.invalidInputMessage
+        }
+    }
+    catch (error) {
+        console.log(error)
+        return constants.operationFailedMessage
+    }
+};
+
+const removeFile = async (workPath, input) => {
+    try {
+        const inputPath = input.substring(removeCommand.length)
+        const fileName = path.join(workPath, inputPath);
+        await fs.unlink(fileName)
+        return ''
+    }
+    catch {
+        return constants.operationFailedMessage
+    }
+};
+
+export {
+    catCommand, addCommand, renameCommand, copyCommand, moveCommand, removeCommand,
+    printFile, createFile, renameFile, copyFile, moveFile, removeFile
+}

--- a/src/fsHelper.js
+++ b/src/fsHelper.js
@@ -1,4 +1,5 @@
-import fs from 'fs/promises';
+import fs from 'fs/promises'
+import path from 'path';
 
 const pathFraming = '"'
 
@@ -54,4 +55,9 @@ const parseTwoPaths = (pathString) => {
     return undefined;
 }
 
-export { pathExists, dirList, direntComparer, getDirentType, parseTwoPaths }
+const join = (workDirectory, userPath) => {
+    return path.isAbsolute(userPath) ? userPath : path.join(workDirectory, userPath)
+
+}
+
+export { pathExists, dirList, direntComparer, getDirentType, parseTwoPaths, join }

--- a/src/fsHelper.js
+++ b/src/fsHelper.js
@@ -1,0 +1,57 @@
+import fs from 'fs/promises';
+
+const pathFraming = '"'
+
+const pathExists = async (path) => {
+
+    try {
+        await fs.stat(path)
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+
+const dirList = async (path) => {
+    return await fs.readdir(path, { withFileTypes: true })
+}
+
+const direntComparer = (a, b) => {
+    {
+        if (a.Type < b.Type)
+            return -1
+        else if (a.Type > b.Type)
+            return 1
+        else if (a.Name < b.Name)
+            return -1
+        return 1;
+    }
+}
+
+const getDirentType = (dirent) => {
+    try {
+        return dirent.isDirectory() ? 'directory' : 'file'
+    }
+    catch {
+        return '---'
+    }
+}
+
+const parseTwoPaths = (pathString) => {
+    if (pathString.indexOf(pathFraming) >= 0) {
+        const pathStringParts = pathString.split(pathFraming)
+        if (pathStringParts.length === 5 && pathStringParts[0] === '' && pathStringParts[2] === ' ' && pathStringParts[4] === '') {
+            return { first: pathStringParts[1], second: pathStringParts[3] }
+        }
+    }
+    else if (pathString.indexOf(' ') > 0) {
+        const pathStringParts2 = pathString.split(' ')
+        if (pathStringParts2.length === 2) {
+            return { first: pathStringParts2[0], second: pathStringParts2[1] }
+        }
+    }
+    return undefined;
+}
+
+export { pathExists, dirList, direntComparer, getDirentType, parseTwoPaths }

--- a/src/greeting.js
+++ b/src/greeting.js
@@ -1,0 +1,23 @@
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const extractUserName = () => {
+    const argPrefix = '--username='
+
+    const arg = process.argv[2];
+    return arg.startsWith(argPrefix) ? arg.substring(argPrefix.length) : ''
+}
+
+const showWelcome = () => {
+    console.log(`Welcome to the File Manager, ${extractUserName()}!`)
+}
+
+const showPath = (currentDirectory) => {
+    console.log(`You are currently in ${currentDirectory}> `)
+}
+
+const showBye = () => {
+    console.log(`Thank you for using File Manager, ${extractUserName()}, goodbye!`)
+};
+
+export { showWelcome, showPath, showBye }

--- a/src/hash&compress.js
+++ b/src/hash&compress.js
@@ -1,0 +1,86 @@
+import { pipeline } from 'stream/promises'
+import { Transform } from 'stream'
+import fs from 'fs'
+import path from 'path'
+import zlib from 'node:zlib'
+import crypto from 'crypto';
+
+import { parseTwoPaths } from './fsHelper.js'
+import constants from './constants.js'
+
+const calcHashCommand = 'hash '
+const compressCommand = 'compress '
+const decompressCommand = 'decompress '
+
+const calculateHash = async (workPath, input) => {
+    try {
+        const inputPath = input.substring(calcHashCommand.length)
+        const fileName = path.join(workPath, inputPath)
+        const readableStream = fs.createReadStream(fileName)
+
+        const hash = crypto.createHash('sha256')
+
+        const transformStream = new Transform({
+            transform(chunk, _, callback) {
+                callback(null, hash.update(chunk).digest('hex'))
+            },
+        });
+        await pipeline(
+            readableStream,
+            transformStream,
+            process.stdout, { end: false }
+        );
+        return ''
+    }
+    catch {
+        return constants.operationFailedMessage
+    }
+};
+
+const compress = async (workPath, input) => {
+    try {
+        const paths = parseTwoPaths(input.substring(compressCommand.length))
+        if (paths) {
+            const toCompressPath = path.join(workPath, paths.first)
+            const archivePath = path.join(workPath, path.second)
+
+            await pipeline(
+                fs.createReadStream(toCompressPath),
+                zlib.createGzip(),
+                fs.createWriteStream(archivePath),
+            );
+            return ''
+        }
+        else {
+            return constants.invalidInputMessage
+        }
+    }
+    catch {
+        return constants.operationFailedMessage
+    }
+}
+
+const decompress = async (workPath, input) => {
+    try {
+        const paths = parseTwoPaths(input.substring(compressCommand.length))
+        if (paths) {
+            const archivePath = path.join(workPath, paths.first)
+            const toDecompressPath = path.join(workPath, path.second)
+
+            await pipeline(
+                fs.createReadStream(archivePath),
+                zlib.createGunzip(),
+                fs.createWriteStream(toDecompressPath),
+            );
+            return ''
+        }
+        else {
+            return constants.invalidInputMessage
+        }
+    }
+    catch {
+        return constants.operationFailedMessage
+    }
+}
+
+export { calcHashCommand, compressCommand, decompressCommand, calculateHash, compress, decompress }

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,12 @@
+import { showWelcome, showPath } from './greeting.js'
+import runManager from './runManager.js'
+
+import os from 'os'
+
+const fileManager = () => {
+    showWelcome();
+    showPath(os.homedir());
+    runManager()
+}
+
+fileManager();

--- a/src/navigation&WorkingDirectory.js
+++ b/src/navigation&WorkingDirectory.js
@@ -1,0 +1,29 @@
+import path from 'path'
+
+const upCommand = 'up'
+const cdCommand = 'cd '
+const lsCommand = 'ls'
+
+import { pathExists, dirList, direntComparer, getDirentType } from './fsHelper.js'
+
+const goUp = (currentDirectory) => {
+    return path.dirname(currentDirectory)
+}
+
+const goInto = async (currentDirectory, input) => {
+    const inputPath = input.substring(cdCommand.length)
+    const newPath = path.resolve(currentDirectory, inputPath)
+    if (await pathExists(newPath)) {
+        return newPath
+    } else {
+        return undefined
+    }
+}
+
+const showList = async (currentDirectory) => {
+    const dirents = await dirList(currentDirectory)
+    const table = dirents.map((dirent) => { return { Name: dirent.name, Type: getDirentType(dirent) } }).sort(direntComparer)
+    console.table(table)
+}
+
+export { upCommand, cdCommand, lsCommand, goUp, goInto, showList }

--- a/src/osInfoOperation.js
+++ b/src/osInfoOperation.js
@@ -1,0 +1,25 @@
+import os from 'os'
+import constants from './constants.js'
+
+const osCommand = 'os '
+
+const getOsInfo = (input) => {
+    switch (input) {
+        case 'os --EOL':
+            return os.EOL
+        case 'os --cpus':
+            const cpusInfo = os.cpus()
+            console.table(cpusInfo.map(cpu => cpu.model))
+            return `Amount of CPUS is ${cpusInfo.length}`
+        case 'os --homedir':
+            return os.homedir
+        case 'os --username':
+            return os.userInfo().username
+        case 'os --architecture':
+            return os.arch()
+        default:
+            return constants.invalidInputMessage
+    }
+}
+
+export { osCommand, getOsInfo }

--- a/src/osInfoOperation.js
+++ b/src/osInfoOperation.js
@@ -6,7 +6,7 @@ const osCommand = 'os '
 const getOsInfo = (input) => {
     switch (input) {
         case 'os --EOL':
-            return os.EOL
+            return JSON.stringify(os.EOL)
         case 'os --cpus':
             const cpusInfo = os.cpus()
             console.table(cpusInfo.map(cpu => cpu.model))

--- a/src/runManager.js
+++ b/src/runManager.js
@@ -1,0 +1,108 @@
+import stream from 'stream';
+import os from 'os'
+
+
+import { showBye } from './greeting.js'
+import { upCommand, cdCommand, lsCommand, goUp, goInto, showList } from './navigation&WorkingDirectory.js'
+import {
+    catCommand, addCommand, renameCommand, copyCommand, moveCommand, removeCommand,
+    printFile, createFile, renameFile, copyFile, moveFile, removeFile
+} from './fileOperations.js'
+import { osCommand, getOsInfo } from './osInfoOperation.js';
+import { calcHashCommand, compressCommand, decompressCommand, calculateHash, compress, decompress } from './hash&compress.js';
+import constants from './constants.js';
+
+let currentDirectory = os.homedir()
+
+const exitCommand = '.exit'
+
+const changeDirectory = async (input) => {
+    const newPath = await goInto(currentDirectory, input)
+    if (newPath) {
+        currentDirectory = newPath
+        return ''
+    } else {
+        return constants.operationFailedMessage
+    }
+}
+
+const defineCommand = async (input) => {
+    if (input === exitCommand) {
+        showBye()
+        process.exit(0)
+    }
+
+    // ---   NAVIGATION AND WORKING DIRECTORY   ---
+    else if (input === upCommand) {
+        currentDirectory = goUp(currentDirectory);
+        return ''
+    }
+
+    else if (input.startsWith(cdCommand)) {
+        return await changeDirectory(input)
+    }
+
+    else if (input === lsCommand) {
+        await showList(currentDirectory)
+        return ''
+    }
+
+    // ---   FILE OPERATIONS   ---
+    else if (input.startsWith(catCommand)) {
+        return await printFile(currentDirectory, input)
+    }
+    else if (input.startsWith(addCommand)) {
+        return await createFile(currentDirectory, input)
+    }
+    else if (input.startsWith(renameCommand)) {
+        return await renameFile(currentDirectory, input)
+    }
+    else if (input.startsWith(copyCommand)) {
+        return await copyFile(currentDirectory, input)
+    }
+    else if (input.startsWith(moveCommand)) {
+        return await moveFile(currentDirectory, input)
+    }
+    else if (input.startsWith(removeCommand)) {
+        return await removeFile(currentDirectory, input)
+    }
+
+    //   ---   GET OS INFO OPERATIONS   ---
+    else if (input.startsWith(osCommand)) {
+        return getOsInfo(input)
+    }
+
+    //   ---   HASH
+    else if (input.startsWith(calcHashCommand)) {
+        return await calculateHash(currentDirectory, input)
+    }
+
+    //   ---   COMPRESS & DECOMPRESS
+    else if (input.startsWith(compressCommand)) {
+        return await compress(currentDirectory, input)
+    }
+    else if (input.startsWith(decompressCommand)) {
+        return await decompress(currentDirectory, input)
+    }
+    return constants.invalidInputMessage
+}
+
+const runManager = () => {
+
+    const transformStream = new stream.Transform({
+        async transform(chunk, _, callback) {
+            let output = ''
+            try {
+                output = await defineCommand(String(chunk).trim('\n'));
+            }
+            catch {
+                output = constants.operationFailedMessage
+            }
+            output += `\nYou are currently in ${currentDirectory}> `
+            callback(null, output);
+        },
+    });
+    process.stdin.pipe(transformStream).pipe(process.stdout);
+};
+
+export default runManager


### PR DESCRIPTION
Use double quotes if path contains spaces, e.g. 
> rn "old file.txt" "new file.txt" 